### PR TITLE
Simplified doctests and made it work in python3

### DIFF
--- a/mdx_outline.py
+++ b/mdx_outline.py
@@ -142,8 +142,9 @@ class OutlineProcessor(Treeprocessor):
 
                 if '%(LEVEL)d' in self.wrapper_cls:
                     wrapper_cls = self.wrapper_cls % {'LEVEL': depth}
-
-                section.attrib['class'] = child.attrib.get('class', wrapper_cls)
+                
+                if self.wrapper_cls:
+                    section.attrib['class'] = child.attrib.get('class', wrapper_cls)
 
                 node.remove(child)
 


### PR DESCRIPTION
thanks for this one. it only took one change to make it work in python3 flawlessly!

i also made the doctests simpler. if you want, you can also move the test-function definition into the `if __name__ == '__main__'` body
