### PR TITLE
Don’t import itself in setup.py

### DIFF
--- a/mdx_outline.py
+++ b/mdx_outline.py
@@ -142,7 +142,7 @@ from markdown import Extension
 from markdown.treeprocessors import Treeprocessor
 
 
-__version__ = "1.02"
+__version__ = "1.02.1"
 
 
 class OutlineProcessor(Treeprocessor):

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,11 @@
 
 
 from setuptools import setup
-import mdx_outline
 
 
 setup(
     name='mdx_outline',
-    version=mdx_outline.__version__,
+    version='1.02.1',
     author='Alexandre Leray',
     author_email='alexandre@stdin.fr',
     description='Python-Markdown extension to wrap the document logical sections (as implied by h1-h6 headings)',


### PR DESCRIPTION
This depends on Markdown being already installed.
This thus breaks the install process in the scenario where
mdx_outline.py is included as a requirement (along with Markdown) in a setup.py
or a requirements.txt.
