### PR TITLE
Replace deprecated getchildren() with list()

### DIFF
--- a/mdx_outline.py
+++ b/mdx_outline.py
@@ -151,7 +151,7 @@ class OutlineProcessor(Treeprocessor):
         pattern = re.compile('^h(\d)')
         wrapper_cls = self.wrapper_cls
 
-        for child in node.getchildren():
+        for child in list(node):
             match = pattern.match(child.tag.lower())
 
             if match:


### PR DESCRIPTION
elem.getchildren() was deprecated since Python version 3.2, and
removed in version 3.9. This commit replaces it with list(elem).